### PR TITLE
Fix: Update build tools version to allow compilation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 34
-    buildToolsVersion "34.0.0"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "ru.henridellal.dialer"


### PR DESCRIPTION
I changed the Android buildToolsVersion in app/build.gradle from "34.0.0" to "30.0.3".

This change was necessary because the original Build Tools version 34.0.0 was missing the 'dx' tool, causing the build to fail. With buildToolsVersion "30.0.3", the application compiles successfully.